### PR TITLE
Disable cleartext traffic in AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="false"
         android:theme="@style/Theme.OnCampusApp">
 
         <receiver


### PR DESCRIPTION
Fixes security issue, forcing traffic through HTTPS instead of HTTP